### PR TITLE
Add missing externs in bsd-getopt-long.h

### DIFF
--- a/bsd-getopt-long.h
+++ b/bsd-getopt-long.h
@@ -97,6 +97,12 @@ int pure_getopt_long_only(int nargc, char * const *nargv,
 
 int pure_getopt(int nargc, char * const *nargv, const char *options);
 
+extern const char *pure_optarg;            /* getopt(3) external variables */
+extern int pure_opterr;
+extern int pure_optind;
+extern int pure_optopt;
+extern int pure_optreset;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Without these externs, including the header file results in errors about missing symbols due to the `#define`s later in the header. See the related Zeek PR for more details about the errors.