### PR TITLE
Fix GCC 12.2 warning in access to patricia_t members

### DIFF
--- a/patricia.c
+++ b/patricia.c
@@ -209,6 +209,7 @@ prefix_t *New_Prefix2(int family, void *dest, int bitlen, prefix_t *prefix)
 {
   int dynamic_allocated = 0;
   int default_bitlen = sizeof(struct in_addr) * 8;
+  prefix4_t *p4 = NULL;
 
 #ifdef HAVE_IPV6
   if (family == AF_INET6) {
@@ -243,11 +244,12 @@ prefix_t *New_Prefix2(int family, void *dest, int bitlen, prefix_t *prefix)
       return (NULL);
     }
 
-  prefix->bitlen = (bitlen >= 0) ? bitlen : default_bitlen;
-  prefix->family = family;
-  prefix->ref_count = 0;
+  p4 = (prefix4_t*) prefix;
+  p4->bitlen = (bitlen >= 0) ? bitlen : default_bitlen;
+  p4->family = family;
+  p4->ref_count = 0;
   if (dynamic_allocated) {
-    prefix->ref_count++;
+    p4->ref_count++;
   }
   /* fprintf(stderr, "[C %s, %d]\n", prefix_toa (prefix), prefix->ref_count);
    */


### PR DESCRIPTION
Access to members of the larger `prefix_t`, while safe, throws warnings when the compiler knows it previously allocated the smaller `prefix4_t`. Example here: https://cirrus-ci.com/task/5579628042518528?logs=build#L2887

Adapted from 11ae12079ca716f8cfac42cccfd905dad45da18f in the upstream repo.