### PR TITLE
Fix rampant off-by-one error in last change

### DIFF
--- a/modp_numtoa.c
+++ b/modp_numtoa.c
@@ -116,7 +116,7 @@ size_t modp_itoa10(int32_t value, char* str)
 
     // Reverse string
     strreverse(str,wstr-1);
-    return wstr - str - 1;
+    return wstr - str;
 }
 
 size_t modp_uitoa10(uint32_t value, char* str)
@@ -127,7 +127,7 @@ size_t modp_uitoa10(uint32_t value, char* str)
     *wstr='\0';
     // Reverse string
     strreverse(str, wstr-1);
-    return wstr - str - 1;
+    return wstr - str;
 }
 
 size_t modp_litoa10(int64_t value, char* str)
@@ -142,7 +142,7 @@ size_t modp_litoa10(int64_t value, char* str)
 
     // Reverse string
     strreverse(str,wstr-1);
-    return wstr - str - 1;
+    return wstr - str;
 }
 
 size_t modp_ulitoa10(uint64_t value, char* str)
@@ -153,7 +153,7 @@ size_t modp_ulitoa10(uint64_t value, char* str)
     *wstr='\0';
     // Reverse string
     strreverse(str, wstr-1);
-    return wstr - str - 1;
+    return wstr - str;
 }
 
 size_t modp_dtoa(double value, char* str, int prec)
@@ -251,7 +251,7 @@ size_t modp_dtoa(double value, char* str, int prec)
     }
     *wstr='\0';
     strreverse(str, wstr-1);
-    return wstr - str - 1;
+    return wstr - str;
 }
 
 
@@ -372,7 +372,7 @@ size_t modp_dtoa2(double value, char* str, int prec)
     }
     *wstr='\0';
     strreverse(str, wstr-1);
-    return wstr - str - 1;
+    return wstr - str;
 }
 
 // This is near identical to modp_dtoa2 above, excep that it never uses
@@ -502,5 +502,5 @@ size_t modp_dtoa3(double value, char* str, int n, int prec)
     }
     *wstr='\0';
     strreverse(str, wstr-1);
-    return wstr - str - 1;
+    return wstr - str;
 }


### PR DESCRIPTION
In my last change I modified the numeric conversion routines to return the number of characters in the conversion.  All of these computations were off-by-one, an issue that the test suite tickles but somehow I missed when doing the change.  This PR addresses the issue.