### PR TITLE
Add .clang-format that disables all formatting for this directory

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+# See the file "COPYING" in the main distribution directory for copyright.
+
+# This file exists to prevent files in this directory from being formatted.
+{
+    "DisableFormat": true,
+}


### PR DESCRIPTION
Most of the files in this directory originated from external code or projects and we shouldn't enforce our formatting on them. This came up because my editor automatically runs clang-format on save, and was pulling the configuration from the parent zeek directory.